### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/lcmen/lcmen.github.io/security/code-scanning/1](https://github.com/lcmen/lcmen.github.io/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block that grants only the least privileges required. For this workflow, the steps only need to read the repository contents; they do not push commits, create releases, or modify issues, so `contents: read` is sufficient.

The best fix without changing existing functionality is to add a workflow-level `permissions` block just under the `name: CI` line. That way, all jobs inherit restricted permissions unless they override them. Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between lines 1 and 3 (after `name: CI` and before `on:`). No additional imports or methods are needed because this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
